### PR TITLE
Add React + Tailwind landing page skeleton

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sushi Bar</title>
+    <link rel="icon" href="/favicon.ico" />
+  </head>
+  <body class="bg-dark text-light font-sans">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sushibar",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.12.16"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.1",
+    "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.0.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/images/dish1.png
+++ b/public/images/dish1.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/dish2.png
+++ b/public/images/dish2.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/dish3.png
+++ b/public/images/dish3.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/dish4.png
+++ b/public/images/dish4.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/plate.png
+++ b/public/images/plate.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/salmon1.png
+++ b/public/images/salmon1.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/salmon2.png
+++ b/public/images/salmon2.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/salmon3.png
+++ b/public/images/salmon3.png
@@ -1,0 +1,1 @@
+placeholder

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Hero from './components/Hero';
+import Menu from './components/Menu';
+import About from './components/About';
+import Reservation from './components/Reservation';
+
+export default function App() {
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-dark text-light">
+      <Hero />
+      <Menu />
+      <About />
+      <Reservation />
+    </div>
+  );
+}

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function About() {
+  return (
+    <section id="about" className="py-24 bg-gradient-to-b from-black to-dark">
+      <div className="max-w-4xl mx-auto px-4 text-center">
+        <motion.h2
+          className="text-4xl font-bold mb-6"
+          initial={{ opacity: 0, y: 50 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          Nossa Hist\u00f3ria
+        </motion.h2>
+        <motion.p
+          className="text-gray-300 leading-relaxed"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+        >
+          Fundado em 2023, o Sushi Bar traz a aut\u00eantica culin\u00e1ria japonesa com um toque contempor\u00e2neo. Nossa miss\u00e3o \u00e9 proporcionar uma experi\u00eancia gastron\u00f4mica inesquec\u00edvel em um ambiente sofisticado.
+        </motion.p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const salmonPieces = [
+  '/images/salmon1.png',
+  '/images/salmon2.png',
+  '/images/salmon3.png',
+];
+
+export default function Hero() {
+  return (
+    <section className="relative flex flex-col items-center justify-center h-screen bg-gradient-to-b from-dark to-black">
+      {salmonPieces.map((src, index) => (
+        <motion.img
+          key={index}
+          src={src}
+          alt="salmon piece"
+          initial={{ y: -200, opacity: 0 }}
+          animate={{ y: 0, opacity: 1, rotate: 360 }}
+          transition={{ delay: index * 0.3, duration: 1 }}
+          className="absolute w-20 h-20 object-cover"
+          style={{ top: `${index * 20}px` }}
+        />
+      ))}
+      <motion.img
+        src="/images/plate.png"
+        alt="plate"
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ delay: 1, type: 'spring', stiffness: 120 }}
+        className="w-64 h-64 object-contain mt-20"
+      />
+      <motion.h1
+        className="text-5xl font-bold mt-8 text-light"
+        initial={{ opacity: 0, y: -50 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5 }}
+      >
+        Bem-vindo ao Sushi Bar
+      </motion.h1>
+    </section>
+  );
+}

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const dishes = [
+  { name: 'Sashimi Especial', description: 'Fatias finas de peixe fresco', image: '/images/dish1.png' },
+  { name: 'Sushi Premium', description: 'Sele\u00e7\u00e3o dos melhores sushis', image: '/images/dish2.png' },
+  { name: 'Tempur\u00e1 de Camar\u00e3o', description: 'Croc\u00e2ncia perfeita', image: '/images/dish3.png' },
+  { name: 'Uramaki Especial', description: 'Recheios exclusivos', image: '/images/dish4.png' },
+];
+
+export default function Menu() {
+  return (
+    <section id="menu" className="py-24 bg-dark">
+      <h2 className="text-4xl font-bold text-center mb-12">Card\u00e1pio</h2>
+      <div className="space-y-16">
+        {dishes.map((dish, index) => (
+          <motion.div
+            key={index}
+            className={`flex flex-col md:flex-row items-center md:items-start md:space-x-8 ${index % 2 ? 'md:flex-row-reverse' : ''}`}
+            initial={{ opacity: 0, x: index % 2 ? 100 : -100 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <img src={dish.image} alt={dish.name} className="w-64 h-64 object-cover rounded-lg shadow-lg" />
+            <div className="mt-4 md:mt-0">
+              <h3 className="text-2xl font-semibold mb-2">{dish.name}</h3>
+              <p className="text-gray-300">{dish.description}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Reservation.jsx
+++ b/src/components/Reservation.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function Reservation() {
+  return (
+    <section id="reservation" className="py-24 bg-dark">
+      <div className="max-w-xl mx-auto px-4">
+        <motion.h2
+          className="text-4xl font-bold text-center mb-6"
+          initial={{ opacity: 0, y: 50 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          Reserve sua Mesa
+        </motion.h2>
+        <motion.form
+          className="space-y-4"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+        >
+          <input
+            type="text"
+            placeholder="Nome"
+            className="w-full p-2 rounded bg-black text-light placeholder-gray-500"
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            className="w-full p-2 rounded bg-black text-light placeholder-gray-500"
+          />
+          <input
+            type="date"
+            className="w-full p-2 rounded bg-black text-light"
+          />
+          <button
+            type="submit"
+            className="w-full p-2 bg-red-600 rounded hover:bg-red-700 transition-colors"
+          >
+            Reservar
+          </button>
+        </motion.form>
+      </div>
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-dark text-light;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        dark: '#0d0d0d',
+        light: '#f5f5f5',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up Vite config with React and Tailwind
- create public placeholders and Tailwind CSS config
- implement basic hero animation with Framer Motion
- lay out menu, about and reservation sections

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fe21d44483339fea92ab9f86b6f6